### PR TITLE
fix mindslaves

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1622,7 +1622,7 @@
 	to_chat(current, "<span class='warning'><B>You're now a loyal zealot of [missionary.name]!</B> You now must lay down your life to protect [missionary.p_them()] and assist in [missionary.p_their()] goals at any cost.</span>")
 	
 	var/datum/antagonist/traitor/custom/C = new()
-	C.should_greet = FALSE
+	C.silent = TRUE
 	var/datum/objective/protect/zealot_objective = new
 	zealot_objective.target = missionary.mind
 	zealot_objective.owner = src

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -48,10 +48,6 @@
 			break
 		var/datum/mind/traitor = pick(possible_traitors)
 		traitors += traitor
-		traitor.special_role = SPECIAL_ROLE_TRAITOR
-		var/datum/mindslaves/slaved = new()
-		slaved.masters += traitor
-		traitor.som = slaved //we MIGHT want to mindslave someone
 		traitor.restricted_roles = restricted_jobs
 		possible_traitors.Remove(traitor)
 

--- a/code/game/objects/items/weapons/implants/implant_traitor.dm
+++ b/code/game/objects/items/weapons/implants/implant_traitor.dm
@@ -70,10 +70,8 @@
 			MS.target = user.mind
 			MS.explanation_text = "Obey every order from and protect [user.real_name], the [user.mind.assigned_role == user.mind.special_role ? (user.mind.special_role) : (user.mind.assigned_role)]."
 			var/datum/antagonist/traitor/custom/C = new()
-			C.should_greet = FALSE
-			mindslave_target.mind.add_antag_datum(C)
 			C.add_objective(MS)
-			mindslave_target.mind.announce_objectives()
+			mindslave_target.mind.add_antag_datum(C)
 
 			var/datum/mindslaves/slaved = user.mind.som
 			mindslave_target.mind.som = slaved

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1968,7 +1968,7 @@
 					var/datum/mind/newtraitormind = pick(possible_traitors)
 					var/datum/antagonist/traitor/custom/C = new()
 					C.should_equip = TRUE
-					C.should_greet = FALSE
+					C.silent = TRUE
 					var/datum/objective/assassinate/kill_objective = new()
 					kill_objective.target = H.mind
 					kill_objective.owner = newtraitormind

--- a/code/modules/antagonists/traitor/traitor.dm
+++ b/code/modules/antagonists/traitor/traitor.dm
@@ -11,7 +11,6 @@
 	var/give_objectives = TRUE
 	var/should_give_codewords = TRUE
 	var/should_equip = TRUE
-	var/should_greet = TRUE
 	var/traitor_kind = TRAITOR_HUMAN //Set on initial assignment
 	var/list/assigned_targets = list()
 
@@ -27,11 +26,14 @@
 	if(owner.current && isAI(owner.current))
 		traitor_kind = TRAITOR_AI
 
+	var/datum/mindslaves/slaved = new()
+	slaved.masters += owner
+	owner.som = slaved //we MIGHT want to mindslave someone
 	SSticker.mode.traitors += owner
 	owner.special_role = special_role
 	if(give_objectives)
 		forge_traitor_objectives()
-	if(should_greet)
+	if(!silent)
 		greet()
 	update_traitor_icons_added()
 	finalize_traitor()
@@ -59,14 +61,14 @@
 		if(traitor_mob && istype(traitor_mob))
 			if(!silent)
 				to_chat(traitor_mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
-			traitor_mob.mutations.Add(CLUMSY)
+			traitor_mob.mutations.Remove(CLUMSY)
 
 
 /datum/antagonist/traitor/remove_innate_effects()
 	if(owner.assigned_role == "Clown")
 		var/mob/living/carbon/human/traitor_mob = owner.current
 		if(traitor_mob && istype(traitor_mob))
-			traitor_mob.mutations.Remove(CLUMSY) 
+			traitor_mob.mutations.Add(CLUMSY) 
 
 
 /datum/antagonist/traitor/proc/add_objective(datum/objective/O)
@@ -209,7 +211,7 @@
 
 /datum/antagonist/traitor/greet()
 	to_chat(owner.current, "<B><font size=3 color=red>You are a [owner.special_role]!</font></B>")
-	if(LAZYLEN(objectives))
+	if(!LAZYLEN(objectives))
 		to_chat(owner.current, "<span>You don't have any objectives right now.</span>")
 	else
 		owner.announce_objectives()


### PR DESCRIPTION
Handles the .som stuff in the datum antag of traitor and replaces should_greet with the silent variable that all datum antags use instead to avoid variable bloat also fixes it giving you clumsy as a clown when getting antag and removing it when losing it(this code should be replaced with the clumsy toggle action later anyway) 
